### PR TITLE
Round corrected time to nearest 0.1 second

### DIFF
--- a/src/pages/HRace.tsx
+++ b/src/pages/HRace.tsx
@@ -319,6 +319,7 @@ const RacePage = () => {
             let seconds = result.finishTime - race.startTime
             console.log(seconds)
             result.CorrectedTime = (seconds * 1000 * (maxLaps / result.lapTimes.times.length)) / result.boat.py
+            result.CorrectedTime = Math.round(result.CorrectedTime*10)/10
             console.log(result.CorrectedTime)
             if (result.finishTime == -1) {
                 result.CorrectedTime = 99999


### PR DESCRIPTION
Fixes #39 
Rounds results during calculation to the nearest 01. second. This feels accurate enough to me?